### PR TITLE
Refactor variable declarations in extractors to use 'val' instead of …

### DIFF
--- a/BelgeselX/src/main/kotlin/com/keyiflerolsun/OdnoklassnikiExtractor.kt
+++ b/BelgeselX/src/main/kotlin/com/keyiflerolsun/OdnoklassnikiExtractor.kt
@@ -29,7 +29,7 @@ open class Odnoklassniki : ExtractorApi() {
 
             var videoUrl  = if (video.url.startsWith("//")) "https:${video.url}" else video.url
 
-            var quality   = video.name.uppercase()
+            val quality   = video.name.uppercase()
                 .replace("MOBILE", "144p")
                 .replace("LOWEST", "240p")
                 .replace("LOW",    "360p")

--- a/CanliTV/src/main/kotlin/com/keyiflerolsun/CanliTV.kt
+++ b/CanliTV/src/main/kotlin/com/keyiflerolsun/CanliTV.kt
@@ -124,7 +124,7 @@ class CanliTV : MainAPI() {
         val kanal    = kanallar.items.first { it.url == loadData.url }
         Log.d("IPTV", "kanal » $kanal")
 
-        var referer = kanal.headers["referrer"] ?: ""
+        val referer = kanal.headers["referrer"] ?: ""
         
         callback.invoke(
             newExtractorLink(

--- a/CizgiMax/src/main/kotlin/com/keyiflerolsun/CizgiDuoExtractor.kt
+++ b/CizgiMax/src/main/kotlin/com/keyiflerolsun/CizgiDuoExtractor.kt
@@ -23,13 +23,14 @@ open class CizgiDuo : ExtractorApi() {
         val encrypted    = AesHelper.cryptoAESHandler(bePlayerData, bePlayerPass.toByteArray(), false)?.replace("\\", "") ?: throw ErrorLoadingException("failed to decrypt")
         Log.d("Kekik_${this.name}", "encrypted » $encrypted")
 
-        m3uLink = Regex("""video_location":"([^"]+)""").find(encrypted)?.groupValues?.get(1)
+        val m3uLink = Regex("""video_location":"([^"]+)""").find(encrypted)?.groupValues?.get(1)
+                     ?: throw ErrorLoadingException("m3u link not found")
 
         callback.invoke(
             newExtractorLink(
                 this.name,
                 this.name,
-                m3uLink ?: throw ErrorLoadingException("m3u link not found"),
+                m3uLink,
             ) {
                 this.referer = url
                 this.quality = Qualities.Unknown.value

--- a/CizgiMax/src/main/kotlin/com/keyiflerolsun/DriveExtractor.kt
+++ b/CizgiMax/src/main/kotlin/com/keyiflerolsun/DriveExtractor.kt
@@ -37,7 +37,6 @@ open class Drive : ExtractorApi() {
             ) {
                 this.referer = url
                 this.quality = Qualities.Unknown.value
-                this.type = INFER_TYPE
             }
         )
     }


### PR DESCRIPTION
…'var' for immutability and clarity.